### PR TITLE
Update architect-orb to v0.8.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@0.8.5
+  architect: giantswarm/architect@0.8.14
 
 version: 2.1
 jobs:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10423.
