### PR TITLE
Remove leftover import comment

### DIFF
--- a/service/controller/todo.go
+++ b/service/controller/todo.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	// If your operator watches a CRD import it here.
-	// "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"


### PR DESCRIPTION
This isn't needed anymore, as of operatorkit v1.0.0.