### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,21 +3,18 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners.
 #
 # Files and directories can be owned by multiple teams, for example:
-# path/to/directory/ @giantswarm/team-x @giantswarm/team-y @giantswarm/team-z
+# /path/to/directory/ @giantswarm/team-x @giantswarm/team-y
 
 # These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
 # @giantswarm/team-x and @giantswarm/team-y will be requested for review when someone opens a pull request.
+# *    @giantswarm/team-x @giantswarm/team-y
 
-# *       @giantswarm/team-x @giantswarm/team-y
+# To add SIG Security to code review with changes in SECURITY.md, uncomment the next line:
+# SECURITY.md @giantswarm/sig-security
 
-# Add SIG Security to code review with changes in SECURITY.md
-SECURITY.md @giantswarm/sig-security
-
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that only
-# modifies golang files, only @go-owner and not the global
-# owner(s) will be requested for a review.
-# *.go    @go-owner
+# Order is important; the last matching pattern takes the most precedence. When someone opens a pull request that only
+# modifies golang files, only @giantswarm/sig-xyz and not the global owner(s) will be requested for a review.
+# *.go    @giantswarm/sig-xyz
 
 # To own any files in the "some/directory" directory at the root of the repository and any of its subdirectories:
 # /some/directory/ @giantswarm/team-z

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,9 +9,6 @@
 # @giantswarm/team-x and @giantswarm/team-y will be requested for review when someone opens a pull request.
 # *    @giantswarm/team-x @giantswarm/team-y
 
-# To add SIG Security to code review with changes in SECURITY.md, uncomment the next line:
-# SECURITY.md @giantswarm/sig-security
-
 # Order is important; the last matching pattern takes the most precedence. When someone opens a pull request that only
 # modifies golang files, only @giantswarm/sig-xyz and not the global owner(s) will be requested for a review.
 # *.go    @giantswarm/sig-xyz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,26 @@
+# This file defines ownership of specific parts of the project. Owner teams will automatically get added as reviewers
+# for pull requests which are modifying files owned by those teams. See official docs for more information
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners.
+#
+# Files and directories can be owned by multiple teams, for example:
+# path/to/directory/ @giantswarm/team-x @giantswarm/team-y @giantswarm/team-z
+
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
+# @giantswarm/team-x and @giantswarm/team-y will be requested for review when someone opens a pull request.
+
+# *       @giantswarm/team-x @giantswarm/team-y
+
+# Add SIG Security to code review with changes in SECURITY.md
+SECURITY.md @giantswarm/sig-security
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies golang files, only @go-owner and not the global
+# owner(s) will be requested for a review.
+# *.go    @go-owner
+
+# To own any files in the "some/directory" directory at the root of the repository and any of its subdirectories:
+# /some/directory/ @giantswarm/team-z
+
+# To own any file in a "some-stuff" directory anywhere in your repository:
+# some-stuff/ @octocat

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
     - Change the badge (with style=shield):
       https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#badges
       If this is a private repository token with scope `status` will be needed.
+    
+    - Update CODEOWNERS file according to the needs for this project
 
     - Run `devctl replace -i "REPOSITORY_NAME" "$(basename $(git rev-parse --show-toplevel))" *.md`
       and commit your changes.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10880

Added CODEOWNERS file with some basic examples. I didn't add any default owners (maybe SECURITY.md could be owned by default by @giantswarm/sig-security).