### PR TITLE
Remove CI env var imports todo from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
     - Add the project to the CircleCI:
       https://circleci.com/setup-project/gh/giantswarm/REPOSITORY_NAME
 
-    - Import RELEASE_TOKEN variable from template repository for the builds:
-      https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#env-vars
-
     - Change the badge (with style=shield):
       https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#badges
       If this is a private repository token with scope `status` will be needed.


### PR DESCRIPTION
Env vars should be imported from architect context.