### PR TITLE
Replace weird characters in Helm release name

### DIFF
--- a/helm/template-operator/templates/_helpers.tpl
+++ b/helm/template-operator/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/template-operator/templates/_helpers.tpl
+++ b/helm/template-operator/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/template-operator/templates/_resource.tpl
+++ b/helm/template-operator/templates/_resource.tpl
@@ -8,7 +8,7 @@ characters for resource names, the stem is truncated to 47 characters to leave
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- .Release.Name | replace "." "-" | replace "_" "-" | replace "#" "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "resource.default.namespace" -}}


### PR DESCRIPTION
Trying to run some tests in the branch used for releases, I got some errors due to bad naming
```failed to create resource: PodSecurityPolicy.extensions "azure-admission-controller-psp" is invalid: metadata.labels: Invalid value: "replace#weird_characters-in-branch": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')```

This is because the branch name is used as label. I believe it's also used as part of the release name. So I added a couple of replaces here and there to clean up the release name.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
